### PR TITLE
refactor: oauth2 인증 처리 개선 - stateless

### DIFF
--- a/src/main/kotlin/com/talk/service/config/Oauth2Config.kt
+++ b/src/main/kotlin/com/talk/service/config/Oauth2Config.kt
@@ -1,0 +1,25 @@
+package com.talk.service.config
+
+import com.talk.service.oauth2.HttpCookieOAuth2AuthorizationRequestRepository
+import com.talk.service.oauth2.OAuth2AuthenticationFailureHandler
+import com.talk.service.oauth2.OAuth2AuthenticationSuccessHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class Oauth2Config {
+
+    @Bean
+    fun httpCookieOAuth2AuthorizationRequestRepository(): HttpCookieOAuth2AuthorizationRequestRepository =
+            HttpCookieOAuth2AuthorizationRequestRepository()
+
+
+    @Bean
+    fun oAuth2AuthenticationFailureHandler(httpCookieOAuth2AuthorizationRequestRepository: HttpCookieOAuth2AuthorizationRequestRepository): OAuth2AuthenticationFailureHandler =
+            OAuth2AuthenticationFailureHandler(httpCookieOAuth2AuthorizationRequestRepository)
+
+    @Bean
+    fun oAuth2AuthenticationSuccessHandler(httpCookieOAuth2AuthorizationRequestRepository: HttpCookieOAuth2AuthorizationRequestRepository): OAuth2AuthenticationSuccessHandler =
+            OAuth2AuthenticationSuccessHandler(httpCookieOAuth2AuthorizationRequestRepository)
+
+}

--- a/src/main/kotlin/com/talk/service/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/talk/service/config/SecurityConfig.kt
@@ -1,15 +1,23 @@
 package com.talk.service.config
 
+import com.talk.service.oauth2.HttpCookieOAuth2AuthorizationRequestRepository
+import com.talk.service.oauth2.OAuth2AuthenticationFailureHandler
+import com.talk.service.oauth2.OAuth2AuthenticationSuccessHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+        private val httpCookieOAuth2AuthorizationRequestRepository: HttpCookieOAuth2AuthorizationRequestRepository,
+        private val oAuth2AuthenticationSuccessHandler: OAuth2AuthenticationSuccessHandler,
+        private val oAuth2AuthenticationFailureHandler: OAuth2AuthenticationFailureHandler
+) {
 
     @Bean
     @Throws(Exception::class)
@@ -17,7 +25,13 @@ class SecurityConfig {
         http.authorizeRequests()
                 .anyRequest().authenticated()
                 .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
                 .oauth2Login()
+                .authorizationEndpoint { it.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository) }
+                .successHandler(oAuth2AuthenticationSuccessHandler)
+                .failureHandler(oAuth2AuthenticationFailureHandler)
         return http.build()
     }
 }

--- a/src/main/kotlin/com/talk/service/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/talk/service/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -1,0 +1,44 @@
+package com.talk.service.oauth2
+
+import com.nimbusds.oauth2.sdk.util.StringUtils
+import com.talk.service.util.CookieUtils
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+
+class HttpCookieOAuth2AuthorizationRequestRepository : AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    override fun loadAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)?.let { CookieUtils.deserialize(it, OAuth2AuthorizationRequest::class.java) }
+    }
+
+    override fun saveAuthorizationRequest(authorizationRequest: OAuth2AuthorizationRequest?, request: HttpServletRequest, response: HttpServletResponse) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME)
+            return
+        }
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds)
+        val redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME)
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds)
+        }
+    }
+
+
+    fun removeAuthorizationRequestCookies(request: HttpServletRequest, response: HttpServletResponse) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME)
+    }
+
+    override fun removeAuthorizationRequest(request: HttpServletRequest, response: HttpServletResponse?): OAuth2AuthorizationRequest? {
+        return loadAuthorizationRequest(request)
+    }
+
+    companion object {
+        const val OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request"
+        const val REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri"
+        private const val cookieExpireSeconds = 180
+    }
+}

--- a/src/main/kotlin/com/talk/service/oauth2/OAuth2AuthenticationFailureHandler.kt
+++ b/src/main/kotlin/com/talk/service/oauth2/OAuth2AuthenticationFailureHandler.kt
@@ -1,0 +1,26 @@
+package com.talk.service.oauth2
+
+import com.talk.service.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.Companion.REDIRECT_URI_PARAM_COOKIE_NAME
+import com.talk.service.util.CookieUtils
+import jakarta.servlet.ServletException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
+import org.springframework.web.util.UriComponentsBuilder
+import java.io.IOException
+
+class OAuth2AuthenticationFailureHandler(
+        private val httpCookieOAuth2AuthorizationRequestRepository: HttpCookieOAuth2AuthorizationRequestRepository
+) : SimpleUrlAuthenticationFailureHandler() {
+
+    @Throws(IOException::class, ServletException::class)
+    override fun onAuthenticationFailure(request: HttpServletRequest, response: HttpServletResponse, exception: AuthenticationException) {
+        var targetUrl: String = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)?.value ?: "/"
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("error", exception.localizedMessage)
+                .build().toUriString()
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response)
+        redirectStrategy.sendRedirect(request, response, targetUrl)
+    }
+}

--- a/src/main/kotlin/com/talk/service/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/talk/service/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -1,0 +1,42 @@
+package com.talk.service.oauth2
+
+import com.talk.service.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.Companion.REDIRECT_URI_PARAM_COOKIE_NAME
+import com.talk.service.util.CookieUtils
+import jakarta.servlet.ServletException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+import org.springframework.web.util.UriComponentsBuilder
+import java.io.IOException
+
+
+class OAuth2AuthenticationSuccessHandler(
+        private val httpCookieOAuth2AuthorizationRequestRepository: HttpCookieOAuth2AuthorizationRequestRepository
+) : SimpleUrlAuthenticationSuccessHandler() {
+
+
+    @Throws(IOException::class, ServletException::class)
+    override fun onAuthenticationSuccess(request: HttpServletRequest, response: HttpServletResponse, authentication: Authentication) {
+        val targetUrl = determineTargetUrl(request, response, authentication)
+        if (response.isCommitted) {
+            logger.debug("Response has already been committed. $targetUrl")
+            return
+        }
+        clearAuthenticationAttributes(request, response)
+        redirectStrategy.sendRedirect(request, response, targetUrl)
+    }
+
+    override fun determineTargetUrl(request: HttpServletRequest, response: HttpServletResponse, authentication: Authentication): String {
+        val redirectUri: String? = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)?.value
+        val defaultTargetUrl = determineTargetUrl(request, response, authentication)
+        val targetUrl: String = redirectUri ?: defaultTargetUrl
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .build().toUriString()
+    }
+
+    private fun clearAuthenticationAttributes(request: HttpServletRequest, response: HttpServletResponse) {
+        super.clearAuthenticationAttributes(request)
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response)
+    }
+}

--- a/src/main/kotlin/com/talk/service/util/CookieUtil.kt
+++ b/src/main/kotlin/com/talk/service/util/CookieUtil.kt
@@ -1,0 +1,54 @@
+package com.talk.service.util
+
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.util.SerializationUtils
+import java.util.*
+
+
+object CookieUtils {
+    fun getCookie(request: HttpServletRequest, name: String): Cookie? {
+        val cookies: Array<Cookie> = request.cookies
+        if (cookies.isNotEmpty()) {
+            for (cookie in cookies) {
+                if (cookie.getName().equals(name)) {
+                    return cookie
+                }
+            }
+        }
+        return null
+    }
+
+    fun addCookie(response: HttpServletResponse, name: String, value: String, maxAge: Int) {
+        val cookie = Cookie(name, value)
+        cookie.setPath("/")
+        cookie.setHttpOnly(true)
+        cookie.setMaxAge(maxAge)
+        response.addCookie(cookie)
+    }
+
+    fun deleteCookie(request: HttpServletRequest, response: HttpServletResponse, name: String) {
+        val cookies: Array<Cookie> = request.cookies
+        if (cookies.isNotEmpty()) {
+            for (cookie in cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("")
+                    cookie.setPath("/")
+                    cookie.setMaxAge(0)
+                    response.addCookie(cookie)
+                }
+            }
+        }
+    }
+
+    fun serialize(`object`: Any): String {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(`object`))
+    }
+
+    fun <T> deserialize(cookie: Cookie, cls: Class<T>): T {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.value)))
+    }
+}


### PR DESCRIPTION
## 요약
- oauth2 login 처리할때 유저 상태를 session 이 아닌 cookie 방식으로 변경
