### PR TITLE
refactor: oauth2-client 승인 설정 수정

### DIFF
--- a/src/main/kotlin/com/talk/client/service/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/talk/client/service/config/SecurityConfig.kt
@@ -5,7 +5,9 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.savedrequest.CookieRequestCache
 
 
 @Configuration
@@ -16,9 +18,11 @@ class SecurityConfig(
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
-
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        http.requestCache().requestCache(CookieRequestCache())
         http.oauth2Client { oauth2Client ->
             oauth2Client.authorizationCodeGrant().authorizationRequestRepository(httpCookieOauth2AuthorizationRequestRepository)
+
         }
 
         return http.build()

--- a/src/main/kotlin/com/talk/client/service/oauth2/HttpCookieOauth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/talk/client/service/oauth2/HttpCookieOauth2AuthorizationRequestRepository.kt
@@ -12,6 +12,7 @@ class HttpCookieOauth2AuthorizationRequestRepository : AuthorizationRequestRepos
 
     private val authorizationRequestName = HttpCookieOauth2AuthorizationRequestRepository::class.java
             .name + ".AUTHORIZATION_REQUEST"
+    private val redirectUriName = "redirect_uri"
 
     private val maxAge = 180
 
@@ -35,6 +36,10 @@ class HttpCookieOauth2AuthorizationRequestRepository : AuthorizationRequestRepos
         Assert.hasText(state, "authorizationRequest.state cannot be empty")
         val authorizationRequestSerializer = CookieUtils.serialize(authorizationRequest)
         CookieUtils.addCookie(response, authorizationRequestName, authorizationRequestSerializer, maxAge)
+        val redirectUri = request.getParameter(redirectUriName)
+        if (!redirectUri.isNullOrBlank()) {
+            CookieUtils.addCookie(response, redirectUriName, redirectUri, maxAge)
+        }
     }
 
     override fun removeAuthorizationRequest(request: HttpServletRequest, response: HttpServletResponse): OAuth2AuthorizationRequest? {
@@ -42,6 +47,7 @@ class HttpCookieOauth2AuthorizationRequestRepository : AuthorizationRequestRepos
         val authorizationRequest = loadAuthorizationRequest(request)
         if (authorizationRequest != null) {
             CookieUtils.deleteCookie(request, response, authorizationRequestName)
+            CookieUtils.deleteCookie(request, response, redirectUriName)
         }
         return authorizationRequest
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
             client-secret: chat-secret
             clientAuthenticationMethod: client_secret_basic
             authorizationGrantType: authorization_code
-            redirectUri: http://talk-server:8080/login/oauth2/code/sso
+            redirectUri: http://talk-client-server:8080/login/oauth2/code/sso
             scope:
               - openid
             clientName: sign in sso


### PR DESCRIPTION
## 요약
- oauth2-client redirect_uri: 도메인 수정
- oauth2 승인하는 경우, redirect_uri 쿠키로 저장
- session 관리 stateless 로 설정
- 요청 cache 는 cookie 로 사용