### PR TITLE
refactor: 인증 설정 개선

### DIFF
--- a/src/main/kotlin/com/talk/client/service/config/Oauth2Config.kt
+++ b/src/main/kotlin/com/talk/client/service/config/Oauth2Config.kt
@@ -1,6 +1,7 @@
 package com.talk.client.service.config
 
 import com.talk.client.service.oauth2.HttpCookieOauth2AuthorizationRequestRepository
+import com.talk.client.service.oauth2.Oauth2AuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
@@ -41,4 +42,8 @@ class Oauth2Config {
     @Bean
     fun httpCookieOauth2AuthorizationRequestRepository(): HttpCookieOauth2AuthorizationRequestRepository =
             HttpCookieOauth2AuthorizationRequestRepository()
+
+    @Bean
+    fun authenticationEntryPoint(): Oauth2AuthenticationEntryPoint =
+            Oauth2AuthenticationEntryPoint()
 }

--- a/src/main/kotlin/com/talk/client/service/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/talk/client/service/config/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package com.talk.client.service.config
 
 import com.talk.client.service.oauth2.HttpCookieOauth2AuthorizationRequestRepository
+import com.talk.client.service.oauth2.Oauth2AuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -13,18 +14,23 @@ import org.springframework.security.web.savedrequest.CookieRequestCache
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-        private val httpCookieOauth2AuthorizationRequestRepository: HttpCookieOauth2AuthorizationRequestRepository
+        private val httpCookieOauth2AuthorizationRequestRepository: HttpCookieOauth2AuthorizationRequestRepository,
+        private val authenticationEntryPoint: Oauth2AuthenticationEntryPoint
 ) {
-
-    @Bean
+     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         http.requestCache().requestCache(CookieRequestCache())
         http.oauth2Client { oauth2Client ->
             oauth2Client.authorizationCodeGrant().authorizationRequestRepository(httpCookieOauth2AuthorizationRequestRepository)
-
         }
-
+        http.formLogin().disable()
+        http.authorizeHttpRequests {
+            it.requestMatchers("/oauth2/login").permitAll()
+            it.anyRequest().authenticated()
+        }
+         http.oauth2ResourceServer().jwt()
+         http.exceptionHandling().authenticationEntryPoint(authenticationEntryPoint)
         return http.build()
     }
 }

--- a/src/main/kotlin/com/talk/client/service/friend/FriendController.kt
+++ b/src/main/kotlin/com/talk/client/service/friend/FriendController.kt
@@ -1,0 +1,14 @@
+package com.talk.client.service.friend
+
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+
+@Controller
+class FriendController {
+
+    @GetMapping("/friends")
+    fun getAll(authentication: Authentication) {
+        println("test: $authentication")
+    }
+}

--- a/src/main/kotlin/com/talk/client/service/oauth2/Oauth2AuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/talk/client/service/oauth2/Oauth2AuthenticationEntryPoint.kt
@@ -1,0 +1,12 @@
+package com.talk.client.service.oauth2
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+class Oauth2AuthenticationEntryPoint: AuthenticationEntryPoint {
+    override fun commence(request: HttpServletRequest, response: HttpServletResponse, authException: AuthenticationException) {
+        response.sendRedirect(Oauth2Constant.LOGIN_URL)
+    }
+}

--- a/src/main/kotlin/com/talk/client/service/oauth2/Oauth2Constant.kt
+++ b/src/main/kotlin/com/talk/client/service/oauth2/Oauth2Constant.kt
@@ -1,0 +1,5 @@
+package com.talk.client.service.oauth2
+
+object Oauth2Constant {
+    val LOGIN_URL = "/oauth2/login"
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,10 @@ server:
 spring:
   security:
     oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://auth-server:9090
+          jwk-set-uri: http://auth-server:9090/oauth2/v1/jwks
       client:
         registration:
           sso: # registrationId


### PR DESCRIPTION
## 요약
- oauth2 인증 필터 추가
- 인증서버의 토큰 암호화 키 정보를 받아서 인증을 수행한다
- 인증이 실패한 경우, 인증 로그인 페이지로 redirect